### PR TITLE
Only reload contacts if relevant SharedPreferences change.

### DIFF
--- a/src/com/android/contacts/common/list/ContactEntryListFragment.java
+++ b/src/com/android/contacts/common/list/ContactEntryListFragment.java
@@ -916,8 +916,9 @@ public abstract class ContactEntryListFragment<T extends ContactEntryListAdapter
             new ContactsPreferences.ChangeListener() {
         @Override
         public void onChange() {
-            loadPreferences();
-            reloadData();
+            if(loadPreferences()) {
+                reloadData();
+            }
         }
     };
 


### PR DESCRIPTION
In ContactEntryListFragment, we listen for any changes to
SharedPreferences. However, not all SharedPreferences should trigger a
data reload.

last_updated_millis will be written if the
smart dial tables in the dialer DB were updated.
mPreferencesChangeListener would reload all contacts data. This shared preference does not change
the data for contacts, so we should not reload them.

On slower devices, this will visibly cause the ListView to flash between the empty view and
populated listitems as it reloads twice when the activity resumes.

Only reload data when relevant SharedPreferences change.

Change-Id: Id2a607fdaf5715b69738c76422ef08d76e6ffafe